### PR TITLE
Added bugfix for drop_exists (report via email from Yuchen)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rdrop2
 Title: Programmatic Interface to the Dropbox API
-Version: 0.5.8.99
+Version: 0.5.9.99
 Authors@R: 'Karthik Ram <karthik.ram@gmail.com> [aut, cre]'
 Description: This package provides full programmatic access to context on the Dropbox platform, including support for all standard file operations.
 Depends: R (>= 3.1.1)

--- a/R/drop_file_ops.R
+++ b/R/drop_file_ops.R
@@ -143,11 +143,12 @@ drop_create <- function (path = NULL, root = "auto", verbose = FALSE, dtoken = g
 #'}
 drop_exists <- function(path = NULL) {
   assert_that(!is.null(path))
-  file_name <- paste0("/", basename(path)) # add a leading slash
+  # file_name <- paste0("/", basename(path)) # add a leading slash
+  if(!grepl('^/', path)) path <- paste0("/", path)
   dir_name <- dirname(path)
   dir_listing <- drop_dir(path = dir_name)
 
-    if(file_name %in% dir_listing$path) {
+    if(path %in% dir_listing$path) {
       TRUE
     } else {
       FALSE

--- a/R/drop_utils.R
+++ b/R/drop_utils.R
@@ -18,7 +18,7 @@ drop_compact <- function(l) Filter(Negate(is.null), l)
 #' @noRd
 strip_slashes <- function(path) {
     if (length(path) && grepl("/$", path)) {
-        path <- substr(path, 1, nchar(path)-1)
+        path <- substr(path, 1, nchar(path) - 1)
     }
     path
 }


### PR DESCRIPTION
`drop_exists` was failing when checking for files inside subfolders. This should fix the problem.