### PR TITLE
fixed the drop_dir external auth bug

### DIFF
--- a/R/drop_dir.R
+++ b/R/drop_dir.R
@@ -80,7 +80,7 @@ drop_dir_internal <- function(path = NULL,
   if(!is.null(path)) {
         metadata_url <- paste0(metadata_url, path)
   }
-  req <- httr::GET(metadata_url, query = args, config(token = get_dropbox_token()))
+  req <- httr::GET(metadata_url, query = args, config(token = dtoken))
   res <- jsonlite::fromJSON(httr::content(req, as = "text"), flatten = TRUE)
   if(length(res$contents) > 0) { # i.e. not an empty folder
   if(verbose) {

--- a/R/drop_file_ops.R
+++ b/R/drop_file_ops.R
@@ -146,11 +146,11 @@ drop_create <- function (path = NULL, root = "auto", verbose = FALSE, dtoken = g
 #' drop_exists("existential_test")
 #' drop_delete("existential_test")
 #'}
-drop_exists <- function(path = NULL) {
+drop_exists <- function(path = NULL, dtoken = get_dropbox_token()) {
   assert_that(!is.null(path))
   if(!grepl('^/', path)) path <- paste0("/", path)
   dir_name <- suppressMessages(dirname(path))
-  dir_listing <- drop_dir_internal(path = dir_name)
+  dir_listing <- drop_dir_internal(path = dir_name, dtoken = dtoken)
 
     if(path %in% dir_listing$path) {
       TRUE

--- a/R/drop_get.R
+++ b/R/drop_get.R
@@ -23,26 +23,26 @@ drop_get <- function(path = NULL,
                      progress = FALSE,
                      dtoken = get_dropbox_token()) {
     stopifnot(!is.null(path))
-      if(drop_exists(path)) {
-    filename <- ifelse(is.null(local_file), basename(path), local_file)
-    get_url <- "https://api-content.dropbox.com/1/files/auto/"
-    args <- as.list(drop_compact(c(rev = rev)))
-    full_download_path <- paste0(get_url, path)
-    if(progress) {
-x <- GET(full_download_path, query = args, config(token = dtoken), write_disk(filename, overwrite = overwrite), progress())
-    } else {
-x <- GET(full_download_path, query = args, config(token = dtoken), write_disk(filename, overwrite = overwrite))
-    }
-    if(!verbose) {
-        # prints file sizes in kb but this could also be pretty printed
-        message(sprintf("\n %s on disk %s KB", filename, length(x$content)/1000, x$url))
-        TRUE
-    } else {        
-        x
-    }
+    if(drop_exists(path, dtoken = dtoken)) {
+        filename <- ifelse(is.null(local_file), basename(path), local_file)
+        get_url <- "https://api-content.dropbox.com/1/files/auto/"
+        args <- as.list(drop_compact(c(rev = rev)))
+        full_download_path <- paste0(get_url, path)
+        if(progress) {
+            x <- GET(full_download_path, query = args, config(token = dtoken), write_disk(filename, overwrite = overwrite), progress())
+        } else {
+            x <- GET(full_download_path, query = args, config(token = dtoken), write_disk(filename, overwrite = overwrite))
+        }
+        if(!verbose) {
+            # prints file sizes in kb but this could also be pretty printed
+            message(sprintf("\n %s on disk %s KB", filename, length(x$content)/1000, x$url))
+            TRUE
+        } else {        
+            x
+        }
    } else {
-    message("File not found on Dropbox \n")
-    FALSE
+       message("File not found on Dropbox \n")
+       FALSE
    } 
 }
 

--- a/R/drop_read_csv.R
+++ b/R/drop_read_csv.R
@@ -13,8 +13,8 @@
 #' # Now let's read this back into an R session
 #' new_iris <- drop_read_csv("iris.csv")
 #'}
-drop_read_csv <- function(file, dest = tempdir(), ...) {
+drop_read_csv <- function(file, dest = tempdir(), dtoken = get_dropbox_token(), ...) {
     localfile = paste0(dest, "/", basename(file))
-    drop_get(file, local_file = localfile, overwrite = TRUE)
+    drop_get(file, local_file = localfile, overwrite = TRUE, dtoken = dtoken)
     read.csv(localfile, ...)
 }


### PR DESCRIPTION
I am using an R API that does not allow me to enter prompts for drop_auth() , so I skip drop_auth() and try to use the dtoken= parameter where possible. It appeared that drop_dir()  consumes it but never actually uses it and defaults to get_dropbox_token() ) which does not work for me.