### PR TITLE
update drop_media.R to API v2

### DIFF
--- a/R/drop_media.R
+++ b/R/drop_media.R
@@ -9,22 +9,20 @@
 #' after 4 hours. So you'll need to cache the content with knitr cache OR re-run
 #' the function call after exipry.
 #'@template path
-#'@template locale
 #' @template token
 #'@export
 #' @examples \dontrun{
 #' drop_media('Public/gifs/duck_rabbit.gif')
 #'}
-drop_media <- function(path = NULL, locale = NULL, dtoken = get_dropbox_token()) {
-      assert_that(!is.null(path))
-         if(drop_exists(path)) {
-       args <- as.list(drop_compact(c(path = path,
-                                locale = locale)))
-   media_url <- "https://api.dropbox.com/1/media/auto/"
-   res <- POST(media_url, query = args, config(token = dtoken), encode = "form")
-   pretty_lists(content(res))
-} else {
+drop_media <- function(path = NULL, dtoken = get_dropbox_token()) {
+  assert_that(!is.null(path))
+  if(drop_exists(path)) {
+    media_url <- "https://api.dropbox.com/2/files/get_temporary_link"
+    path <- paste0("/",path)
+    res <- POST(media_url, body = list(path = path), httr::config(token = dtoken), encode = "json")
+    content(res)
+  } else {
     stop("File not found \n")
     FALSE
-}
+  }
 }

--- a/tests/testthat/test-rdrop2.R
+++ b/tests/testthat/test-rdrop2.R
@@ -207,7 +207,7 @@ test_that("Media URLs work correctly", {
                 destfile = "duck_rabbit.gif")
   drop_upload("duck_rabbit.gif")
   media_url <- drop_media("duck_rabbit.gif")
-  expect_match(media_url$url, "https://dl.dropboxusercontent.com")
+  expect_match(media_url$link, "https://dl.dropboxusercontent.com")
   unlink("duck_rabbit.gif")
   drop_delete("duck_rabbit.gif")
 })


### PR DESCRIPTION
Closes #92. 

No changes to the documentation, other than removing the `locale` argument since it is no longer a parameter in v2.

Note: the returned link to the media content now downloads the file (e.g. `duck_rabbit.gif`) to your local machine instead of streaming it in your browser (which was the behavior in v1) and is contradictory to what the v2 documentation says that link does: 

https://www.dropbox.com/developers/documentation/http/documentation#files-get_temporary_link

