### PR TITLE
Race condition

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,6 +11,7 @@ LazyData: true
 Imports: 
          assertive,
          data.table,
+         digest,
          dplyr,
          httr,
          jsonlite,

--- a/R/drop_upload.R
+++ b/R/drop_upload.R
@@ -69,6 +69,7 @@ drop_upload <- function(file,
   )
   httr::stop_for_status(req)
   response <- httr::content(req)
+
   if (verbose) {
     pretty_lists(response)
     invisible(response)

--- a/tests/testthat/helper-01.R
+++ b/tests/testthat/helper-01.R
@@ -4,10 +4,23 @@
 clean_dropbox <- function(dtoken = get_dropbox_token()) {
   x <-
     readline(
-      "WARNING: this will delete everything in your Dropbox account. Do not do this unless this is a test account. Are you sure?? (y/n)"
+      "WARNING: this will delete everything in your Dropbox account.  \n Do not do this unless this is a test account. Are you sure?? (y/n)"
     )
   if (x == "y") {
     files <- drop_dir()
     sapply(files$path_lower, drop_delete)
   }
+}
+
+
+#' Function makes file/folder names unique to prevent race conditions during concurrent tests. Pun on race condition
+traceless <- function(file) {
+  paste0("rdrop2_package_test_", uuid::UUIDgenerate(), "_", file)
+}
+
+
+# This should clean out any remaining/old test files and folders
+clean_test_data <- function(dtoken = get_dropbox_token()) {
+files <- drop_search("rdrop2_package_test_")
+sapply(files$path_lower, drop_delete)
 }

--- a/tests/testthat/test-02_rdrop2-upload.R
+++ b/tests/testthat/test-02_rdrop2-upload.R
@@ -1,3 +1,4 @@
+# !diagnostics off
 context("Testing drop_upload")
 library(dplyr)
 sprintf("Number of files on Dropbox", nrow(drop_dir("")))
@@ -34,18 +35,17 @@ test_that("Image upload works correctly", {
   skip_on_cran()
   # This test is to see if we can upload an image (a png in this case) and make sure that it maintains file integrity.
   # We compare hashes of local file, then the roundtrip copy.
-
+  dest <- traceless("rdrop2_package_test_drop.png")
   download.file("https://www.dropbox.com/s/k61p0mvapf285cf/business_card.png?dl=0",
-                destfile = "drop-test-business.png")
-  local_file_hash <- digest::digest("drop-test-business.png")
-  # expect_equal(file.info("drop-test-business.png")$size, 227000, tolerance = 500)
-  drop_upload("drop-test-business.png")
-  unlink("drop-test-business.png")
-  drop_download("drop-test-business.png")
-  roundtrip_file_hash <-  digest::digest("drop-test-business.png")
+                destfile = dest)
+  local_file_hash <- digest::digest(dest)
+  drop_upload(dest)
+  unlink(dest)
+  drop_download(dest)
+  roundtrip_file_hash <-  digest::digest(dest)
   expect_equal(local_file_hash, roundtrip_file_hash)
-  drop_delete("/drop-test-business.png")
-  unlink("drop-test-business.png")
+  drop_delete(dest)
+  unlink(dest)
 })
 
 # Test upload of a non existent file
@@ -61,7 +61,6 @@ test_that("Upload of a non-existent file fails", {
 test_that("Autorename upload works correctly", {
 
   autorename_folder <- traceless("autorename_test")
-
   drop_create(autorename_folder)
   blank <- drop_dir(autorename_folder)
   expect_equal(nrow(blank), 0)

--- a/tests/testthat/test-02_rdrop2-upload.R
+++ b/tests/testthat/test-02_rdrop2-upload.R
@@ -78,7 +78,7 @@ test_that("Autorename upload works correctly", {
   # This is what I should expect
   expected_files <-
     c(paste0("/", autorename_folder, "/iris.csv"),
-      paste0("/", add_overwrite_test, "/iris (1).csv"))
+      paste0("/", autorename_folder, "/iris (1).csv"))
   expect_identical(two_files$path_lower, expected_files)
   write.csv(iris[1:5, ], file = "iris.csv")
   drop_upload("iris.csv", path = autorename_folder, mode = "add")

--- a/tests/testthat/test-02_rdrop2-upload.R
+++ b/tests/testthat/test-02_rdrop2-upload.R
@@ -10,7 +10,8 @@ test_that("Test that basic file ops work correctly", {
 
   # This is a simple test to see if we can upload a csv file successfully
 
-  file_name <- paste0(uuid::UUIDgenerate(), "-file-ops-", ".csv")
+  file_name <- traceless("file-ops.csv")
+
   write.csv(mtcars, file_name)
   row_count <- nrow(mtcars)
   print(file_name)
@@ -58,35 +59,38 @@ test_that("Upload of a non-existent file fails", {
 # Test autorename
 # ------------------
 test_that("Autorename upload works correctly", {
-  drop_create("add_overwrite_test")
-  blank <- drop_dir("add_overwrite_test")
+
+  autorename_folder <- traceless("autorename_test")
+
+  drop_create(autorename_folder)
+  blank <- drop_dir(autorename_folder)
   expect_equal(nrow(blank), 0)
   write.csv(iris, file = "iris.csv")
-  drop_upload("iris.csv", path = "add_overwrite_test")
-  one_file <- drop_dir("add_overwrite_test")
+  drop_upload("iris.csv", path = autorename_folder)
+  one_file <- drop_dir(autorename_folder)
   expect_equal(nrow(one_file), 1)
-  expect_identical(one_file[1,]$path_lower, "/add_overwrite_test/iris.csv")
+  expect_identical(one_file[1,]$path_lower, paste0("/", autorename_folder, "/iris.csv"))
   # Write a slightly different object to the same filename
   write.csv(iris[1:6, ], file = "iris.csv")
-  drop_upload("iris.csv", path = "add_overwrite_test", mode = "add")
-  two_files <- drop_dir("add_overwrite_test")
+  drop_upload("iris.csv", path = autorename_folder, mode = "add")
+  two_files <- drop_dir(autorename_folder)
   expect_equal(nrow(two_files), 2)
   # This is what I should expect
   expected_files <-
-    c("/add_overwrite_test/iris.csv",
-      "/add_overwrite_test/iris (1).csv")
+    c(paste0("/", autorename_folder, "/iris.csv"),
+      paste0("/", add_overwrite_test, "/iris (1).csv"))
   expect_identical(two_files$path_lower, expected_files)
   write.csv(iris[1:5, ], file = "iris.csv")
-  drop_upload("iris.csv", path = "add_overwrite_test", mode = "add")
-  three_files <- drop_dir("add_overwrite_test")
+  drop_upload("iris.csv", path = autorename_folder, mode = "add")
+  three_files <- drop_dir(autorename_folder)
   e_3files <-
     c(
-      "/add_overwrite_test/iris.csv",
-      "/add_overwrite_test/iris (1).csv",
-      "/add_overwrite_test/iris (2).csv"
+      paste0("/", autorename_folder, "/iris.csv"),
+      paste0("/", autorename_folder,"/iris (1).csv"),
+      paste0("/", autorename_folder,"/iris (2).csv")
     )
   expect_identical(three_files$path_lower, e_3files)
-  drop_delete("add_overwrite_test")
+  drop_delete(autorename_folder)
   unlink("iris.csv")
 })
 

--- a/tests/testthat/test-04-rdrop2-metadata.R
+++ b/tests/testthat/test-04-rdrop2-metadata.R
@@ -4,7 +4,7 @@ test_that("Able to retrieve metadata for file in multiple ways", {
   skip_on_cran()
 
   # upload new file to root
-  file_name <- paste0("test-drop_get_metadata-", uuid::UUIDgenerate(), ".csv")
+  file_name <- traceless("test-drop-get-metadata.csv")
   write.csv(mtcars, file_name)
   drop_upload(file_name)
 

--- a/tests/testthat/test-05-rdrop2-dir.R
+++ b/tests/testthat/test-05-rdrop2-dir.R
@@ -4,10 +4,13 @@ test_that("drop_dir works as expected", {
   skip_on_cran()
 
   # create folders and objects
-  folder_name <- paste0("test-drop_dir-", uuid::UUIDgenerate())
+  #1
+  # folder_name <- paste0("test-drop_dir-", uuid::UUIDgenerate())
+  folder_name <- traceless("test-drop_dir")
   drop_create(folder_name)
 
-  file_name <- paste0("test-drop_dir-", uuid::UUIDgenerate(), ".csv")
+  # 2
+  file_name <- traceless("test-drop_dir.csv")
   write.csv(mtcars, file_name)
   drop_upload(file_name, path = folder_name)
 
@@ -18,10 +21,12 @@ test_that("drop_dir works as expected", {
   expect_equal(nrow(results), 1)
 
   # add more things
-  subfolder_name <- paste0(folder_name, "/", "test-drop_dir-", uuid::UUIDgenerate())
+  # 3
+  subfolder_name <- paste0(folder_name, "/", traceless("test-drop_subdir"))
   drop_create(subfolder_name)
 
-  subfile_name <- paste0("test-drop_dir-", uuid::UUIDgenerate(), ".csv")
+  # 4
+  subfile_name <- traceless("test-drop-subfile.csv")
   write.csv(iris, subfile_name)
   drop_upload(subfile_name, path = subfolder_name)
 

--- a/tests/testthat/test-05-rdrop2-dir.R
+++ b/tests/testthat/test-05-rdrop2-dir.R
@@ -4,12 +4,9 @@ test_that("drop_dir works as expected", {
   skip_on_cran()
 
   # create folders and objects
-  #1
-  # folder_name <- paste0("test-drop_dir-", uuid::UUIDgenerate())
   folder_name <- traceless("test-drop_dir")
   drop_create(folder_name)
 
-  # 2
   file_name <- traceless("test-drop_dir.csv")
   write.csv(mtcars, file_name)
   drop_upload(file_name, path = folder_name)
@@ -21,11 +18,9 @@ test_that("drop_dir works as expected", {
   expect_equal(nrow(results), 1)
 
   # add more things
-  # 3
   subfolder_name <- paste0(folder_name, "/", traceless("test-drop_subdir"))
   drop_create(subfolder_name)
 
-  # 4
   subfile_name <- traceless("test-drop-subfile.csv")
   write.csv(iris, subfile_name)
   drop_upload(subfile_name, path = subfolder_name)

--- a/tests/testthat/test-06-rdrop2-download.R
+++ b/tests/testthat/test-06-rdrop2-download.R
@@ -4,7 +4,7 @@ test_that("drop_download works as expected", {
   skip_on_cran()
 
   # create and upload a file for testing
-  file_name <- paste0("test-drop_download-", uuid::UUIDgenerate(), ".csv")
+  file_name <- traceless("test-drop-download.csv")
   write.csv(mtcars, file_name)
   drop_upload(file_name)
 
@@ -16,14 +16,14 @@ test_that("drop_download works as expected", {
   )
 
   # download to a new path
-  new_path <- paste0("test-drop_download-", uuid::UUIDgenerate(), ".csv")
+  new_path <- traceless("test-drop_download_newpath.csv")
   expect_identical(
     drop_download(file_name, new_path),
     new_path
   )
 
   # dowload to an implied path
-  new_dir <- paste0("test-drop_download-", uuid::UUIDgenerate())
+  new_dir <- traceless("test-drop_download_newdir")
   dir.create(new_dir)
   implied_path <- file.path(new_dir, file_name)
   expect_identical(

--- a/tests/testthat/test-99-rdrop2.R
+++ b/tests/testthat/test-99-rdrop2.R
@@ -29,16 +29,17 @@ test_that("Moving files works correctly", {
   file_name <- traceless("move.csv")
   write.csv(iris, file = file_name)
   drop_upload(file_name)
-  drop_create("move_test")
-  drop_move(file_name, paste0("/move_test/", file_name))
-  res <- drop_dir("move_test")
+  mtest <- traceless("move_test")
+  drop_create(mtest)
+  drop_move(file_name, paste0("/", mtest, "/", file_name))
+  res <- drop_dir(mtest)
   # problem
   expect_identical(basename(file_name), basename(res$path_lower))
   # Now test that the file is there.
   # do a search for the path/file
   # the make sure it exists
   # ......................................
-  drop_delete("/move_test")
+  drop_delete(mtest)
   unlink(file_name)
 })
 

--- a/tests/testthat/test-99-rdrop2.R
+++ b/tests/testthat/test-99-rdrop2.R
@@ -7,7 +7,7 @@
 # ......................................
 test_that("Copying files works correctly", {
   skip_on_cran()
-  file_name <- paste0(uuid::UUIDgenerate(), "-copy-", "d")
+  file_name <- traceless("copy.csv")
   write.csv(iris, file = file_name)
   drop_upload(file_name)
   drop_create("copy_test")
@@ -26,7 +26,7 @@ test_that("Copying files works correctly", {
 # ......................................
 test_that("Moving files works correctly", {
   skip_on_cran()
-  file_name <- paste0(uuid::UUIDgenerate(), "-move-", "d")
+  file_name <- traceless("move.csv")
   write.csv(iris, file = file_name)
   drop_upload(file_name)
   drop_create("move_test")
@@ -47,7 +47,7 @@ test_that("Moving files works correctly", {
 context("testing drop share")
 test_that("Sharing a Dropbox resource works correctly", {
   skip_on_cran()
-  file_name <- paste0(uuid::UUIDgenerate(), "-share", ".csv")
+  file_name <- traceless("share.csv")
   write.csv(iris, file = file_name)
   drop_upload(file_name)
   res <- drop_share(file_name)
@@ -71,7 +71,8 @@ test_that("Drop search works correctly", {
 
   skip_on_cran()
 
-  folder_name <- paste0("test-drop_search-", uuid::UUIDgenerate())
+  folder_name <- traceless("test-drop_search")
+    #paste0("test-drop_search-", uuid::UUIDgenerate())
   drop_create(folder_name)
 
   write.csv(mtcars, "mtcars.csv")
@@ -116,7 +117,7 @@ test_that("We can verify that a file exists on Dropbox", {
 
   drop_create("existential_test")
   expect_true(drop_exists("existential_test"))
-  expect_false(drop_exists(paste0(uuid::UUIDgenerate(), uuid::UUIDgenerate(), "d")))
+  expect_false(drop_exists(traceless("stuffnthings")))
   # Now test files inside subfolders
   write.csv(iris, file = "iris.csv")
   drop_upload("iris.csv", path = "existential_test")
@@ -146,7 +147,7 @@ context("Testing drop_read_csv")
 test_that("Can read csv files directly from dropbox", {
   skip_on_cran()
 
-  file_name <- paste0(uuid::UUIDgenerate(), "-drop_read-", ".csv")
+  file_name <- traceless("drop_read.csv")
   write.csv(iris, file = file_name)
   drop_upload(file_name)
   z <- drop_read_csv(file_name)
@@ -161,7 +162,7 @@ context("Drop delta works")
 test_that("Drop delta works", {
   skip_on_cran()
 
-  file_name <- paste0(uuid::UUIDgenerate(), "-drop_delta-", ".csv")
+  file_name <- traceless("drop-delta.csv")
   write.csv(iris, file = file_name)
   z <- drop_delta(path_prefix = "/")
   expected_names <- c("has_more", "cursor", "entries", "reset")


### PR DESCRIPTION
@ClaytonJY This should be a very simple PR to merge. Just check this out, run the tests and make sure everything passes. The meat of of this is a function called `traceless` which uuids any file/folder name. So we should never run into a race condition again. 

As a bonus, this could also run on a production account and test files can easily be deleted with a new function which looks for any object that begins with `rdrop2_package_test_` and deletes that.