### PR TITLE
Drop ops

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,8 @@ Imports:
          dplyr,
          httr,
          jsonlite,
-         magrittr
+         magrittr,
+         purrr
 Suggests: testthat,
           uuid
 RoxygenNote: 6.0.1

--- a/R/drop_file_ops.R
+++ b/R/drop_file_ops.R
@@ -220,7 +220,10 @@ drop_create <-
            autorename = FALSE,
            verbose = FALSE,
            dtoken = get_dropbox_token()) {
-    if (!drop_exists(path)) {
+
+   # if a folder exists, but autorename is TRUE, proceed
+   # However, if a folder exists, and autorename if FALSE, fail in the else.
+    if (!drop_exists(path) || autorename) {
       create_url <- "https://api.dropboxapi.com/2/files/create_folder_v2"
 
       path <- add_slashes(path)
@@ -232,7 +235,7 @@ drop_create <-
           encode = "json"
         )
       results <- httr::content(x)
-      browser()
+
       if (verbose) {
         pretty_lists(results)
         invisible(results)

--- a/man/drop_copy.Rd
+++ b/man/drop_copy.Rd
@@ -4,16 +4,24 @@
 \alias{drop_copy}
 \title{Copies a file or folder to a new location.}
 \usage{
-drop_copy(from_path = NULL, to_path = NULL, root = "auto",
-  verbose = FALSE, dtoken = get_dropbox_token())
+drop_copy(from_path = NULL, to_path = NULL, allow_shared_folder = FALSE,
+  autorename = FALSE, allow_ownership_transfer = FALSE, verbose = FALSE,
+  dtoken = get_dropbox_token())
 }
 \arguments{
 \item{from_path}{Source file or folder}
 
 \item{to_path}{destination file or folder}
 
-\item{root}{This is required. The root relative to which path is specified.
-Valid values are auto (recommended and also the default), sandbox, and dropbox.}
+\item{allow_shared_folder}{If \code{TRUE}, copy will copy contents in shared
+folder}
+
+\item{autorename}{If there's a conflict, have the Dropbox server try to
+autorename the file to avoid the conflict.}
+
+\item{allow_ownership_transfer}{Allow moves by owner even if it would result
+in an ownership transfer for the content being moved. This does not apply
+to copies. The default for this field is False.}
 
 \item{verbose}{By default verbose output is \code{FALSE}. Set to \code{TRUE}
 if you need to troubleshoot any output or grab additional parameters.}

--- a/man/drop_create.Rd
+++ b/man/drop_create.Rd
@@ -4,15 +4,14 @@
 \alias{drop_create}
 \title{Creates a folder on Dropbox}
 \usage{
-drop_create(path = NULL, root = "auto", verbose = FALSE,
+drop_create(path = NULL, autorename = FALSE, verbose = FALSE,
   dtoken = get_dropbox_token())
 }
 \arguments{
 \item{path}{This is required The path to the new folder to create relative to
 root.}
 
-\item{root}{This is required. The root relative to which path is specified.
-Valid values are auto (recommended and also the default), sandbox, and dropbox.}
+\item{autorename}{Set to \code{TRUE} to automatically rename. Default is FALSE.}
 
 \item{verbose}{By default verbose output is \code{FALSE}. Set to \code{TRUE}
 if you need to troubleshoot any output or grab additional parameters.}

--- a/man/drop_delete.Rd
+++ b/man/drop_delete.Rd
@@ -4,15 +4,11 @@
 \alias{drop_delete}
 \title{Deletes a file or folder.}
 \usage{
-drop_delete(path = NULL, root = "auto", verbose = FALSE,
-  dtoken = get_dropbox_token())
+drop_delete(path = NULL, verbose = FALSE, dtoken = get_dropbox_token())
 }
 \arguments{
 \item{path}{This is required The path to the new folder to create relative to
 root.}
-
-\item{root}{This is required. The root relative to which path is specified.
-Valid values are auto (recommended and also the default), sandbox, and dropbox.}
 
 \item{verbose}{By default verbose output is \code{FALSE}. Set to \code{TRUE}
 if you need to troubleshoot any output or grab additional parameters.}

--- a/man/drop_move.Rd
+++ b/man/drop_move.Rd
@@ -4,16 +4,24 @@
 \alias{drop_move}
 \title{Moves a file or folder to a new location.}
 \usage{
-drop_move(from_path = NULL, to_path = NULL, root = "auto",
-  verbose = FALSE, dtoken = get_dropbox_token())
+drop_move(from_path = NULL, to_path = NULL, allow_shared_folder = FALSE,
+  autorename = FALSE, allow_ownership_transfer = FALSE, verbose = FALSE,
+  dtoken = get_dropbox_token())
 }
 \arguments{
 \item{from_path}{Source file or folder}
 
 \item{to_path}{destination file or folder}
 
-\item{root}{This is required. The root relative to which path is specified.
-Valid values are auto (recommended and also the default), sandbox, and dropbox.}
+\item{allow_shared_folder}{If \code{TRUE}, copy will copy contents in shared
+folder}
+
+\item{autorename}{If there's a conflict, have the Dropbox server try to
+autorename the file to avoid the conflict.}
+
+\item{allow_ownership_transfer}{Allow moves by owner even if it would result
+in an ownership transfer for the content being moved. This does not apply
+to copies. The default for this field is False.}
 
 \item{verbose}{By default verbose output is \code{FALSE}. Set to \code{TRUE}
 if you need to troubleshoot any output or grab additional parameters.}

--- a/tests/testthat/helper-01.R
+++ b/tests/testthat/helper-01.R
@@ -1,14 +1,16 @@
 
 
 #' Use this function to clean out your Dropbox in case there are stray files left over from a failed test.
-clean_dropbox <- function(dtoken = get_dropbox_token()) {
+clean_dropbox <- function(x = "" , dtoken = get_dropbox_token()) {
+  if(x != "y") {
   x <-
     readline(
       "WARNING: this will delete everything in your Dropbox account.  \n Do not do this unless this is a test account. Are you sure?? (y/n)"
     )
+  }
   if (x == "y") {
     files <- drop_dir()
-    sapply(files$path_lower, drop_delete)
+    suppressWarnings(sapply(files$path_lower, drop_delete))
   }
 }
 

--- a/tests/testthat/helper-01.R
+++ b/tests/testthat/helper-01.R
@@ -23,6 +23,14 @@ traceless <- function(file) {
 
 # This should clean out any remaining/old test files and folders
 clean_test_data <- function(dtoken = get_dropbox_token()) {
-files <- drop_search("rdrop2_package_test_")
-sapply(files$path_lower, drop_delete)
+  x <- drop_dir()
+  test_files <- x %>% dplyr::select(name, contains("rdrop_package_test")) %>% pull
+  suppressWarnings(sapply(test_files, drop_delete))
+}
+
+# Counts files matching a pattern
+drop_file_count <- function(x, dtoken = get_dropbox_token()) {
+  y <- drop_dir()
+  z <- grepl(x, y$name)
+  sum(z, na.rm = TRUE)
 }

--- a/tests/testthat/test-07-drop_ops.R
+++ b/tests/testthat/test-07-drop_ops.R
@@ -1,0 +1,55 @@
+context("Testing drop copy")
+# For now I haven't used traceless to make these tests more readable
+# while we work through them
+
+expect_that("drop_copy works correctly", {
+# Copying files to files only
+# ------------------------
+# Copy a file to a new name
+write.csv(iris, "iris.csv")
+drop_upload("iris.csv")
+expect_equal(nrow(drop_dir()), 1)
+# Copy to a new name, same folder
+drop_copy("iris.csv", "iris2.csv")
+expect_equal(nrow(drop_dir()), 2)
+exp_2 <- c("iris2.csv", "iris.csv" )
+server_exp_2 <- drop_dir() %>% dplyr::select(name) %>% pull
+expect_identical(exp_2, server_exp_2)
+# Copy to same name, but autorename is TRUE
+drop_copy('iris.csv', "iris.csv", autorename = TRUE)
+expect_equal(nrow(drop_dir()), 3)
+exp_3 <- c("iris2.csv", "iris.csv", "iris (1).csv")
+server_exp_3 <- drop_dir() %>% dplyr::select(name) %>% pull
+expect_identical(exp_3, server_exp_3)
+
+# Copying files to folders
+# ------------------------
+drop_create("copy_folder")
+drop_copy("iris.csv", "copy_folder")
+dc_dir <-  drop_dir("copy_folder") %>% dplyr::select(name) %>% pull
+expect_equal(dc_dir, "iris.csv")
+
+# Copying folders to existing folders
+# ------------------------
+drop_create("copy_folder_2")
+drop_copy("copy_folder", "copy_folder_2")
+copy_folder_2_contents <- drop_dir("copy_folder_2/copy_folder") %>% dplyr::select(name) %>% pull
+expect_equal(copy_folder_2_contents, "iris.csv")
+
+# Copying files to new folders
+# ------------------------
+drop_copy("copy_folder", "kerfuffle")
+d1 <- drop_dir("copy_folder")  %>% dplyr::select(name) %>% pull
+d2 <- drop_dir("kerfuffle")  %>% dplyr::select(name) %>% pull
+expect_identical(d1, d2)
+
+drop_delete("kerfuffle")
+drop_delete("copy_folder")
+drop_delete("copy_folder_2")
+drop_delete("iris.csv")
+drop_delete("iris2.csv")
+})
+
+# TODO
+# We need to traceless() these files and folders
+# For now, I just wanted to keep them readable

--- a/tests/testthat/test-07-drop_ops.R
+++ b/tests/testthat/test-07-drop_ops.R
@@ -1,3 +1,5 @@
+# !diagnostics off
+
 context("Testing drop copy")
 # For now I haven't used traceless to make these tests more readable
 # while we work through them
@@ -5,6 +7,8 @@ context("Testing drop copy")
 expect_that("drop_copy works correctly", {
 # Copying files to files only
 # ------------------------
+# We need to start with a clean slate
+expect_equal(nrow(drop_dir()), 0)
 # Copy a file to a new name
 write.csv(iris, "iris.csv")
 drop_upload("iris.csv")
@@ -12,14 +16,14 @@ expect_equal(nrow(drop_dir()), 1)
 # Copy to a new name, same folder
 drop_copy("iris.csv", "iris2.csv")
 expect_equal(nrow(drop_dir()), 2)
-exp_2 <- c("iris2.csv", "iris.csv" )
-server_exp_2 <- drop_dir() %>% dplyr::select(name) %>% pull
+exp_2 <- sort(c("iris2.csv", "iris.csv" ))
+server_exp_2 <- drop_dir() %>% dplyr::select(name) %>% pull %>% sort
 expect_identical(exp_2, server_exp_2)
 # Copy to same name, but autorename is TRUE
 drop_copy('iris.csv', "iris.csv", autorename = TRUE)
 expect_equal(nrow(drop_dir()), 3)
-exp_3 <- c("iris2.csv", "iris.csv", "iris (1).csv")
-server_exp_3 <- drop_dir() %>% dplyr::select(name) %>% pull
+exp_3 <- sort(c("iris2.csv", "iris.csv", "iris (1).csv"))
+server_exp_3 <- drop_dir() %>% dplyr::select(name) %>% pull %>% sort
 expect_identical(exp_3, server_exp_3)
 
 # Copying files to folders
@@ -39,8 +43,8 @@ expect_equal(copy_folder_2_contents, "iris.csv")
 # Copying files to new folders
 # ------------------------
 drop_copy("copy_folder", "kerfuffle")
-d1 <- drop_dir("copy_folder")  %>% dplyr::select(name) %>% pull
-d2 <- drop_dir("kerfuffle")  %>% dplyr::select(name) %>% pull
+d1 <- drop_dir("copy_folder")  %>% dplyr::select(name) %>% pull %>% sort
+d2 <- drop_dir("kerfuffle")  %>% dplyr::select(name) %>% pull %>% sort
 expect_identical(d1, d2)
 
 drop_delete("kerfuffle")
@@ -48,8 +52,98 @@ drop_delete("copy_folder")
 drop_delete("copy_folder_2")
 drop_delete("iris.csv")
 drop_delete("iris2.csv")
+drop_delete("iris (1).csv")
 })
 
 # TODO
 # We need to traceless() these files and folders
 # For now, I just wanted to keep them readable
+
+# --------------------------
+# Drop Move
+# --------------------------
+
+
+# drop_move
+test_that("Moving files works correctly", {
+  skip_on_cran()
+
+  file_name <- traceless("move.csv")
+  write.csv(iris, file = file_name)
+  drop_upload(file_name)
+
+  mtest <- traceless("move_test")
+  drop_create(mtest)
+  drop_move(file_name, paste0("/", mtest, "/", file_name))
+  res <- drop_dir(mtest)
+  # problem
+  expect_identical(basename(file_name), basename(res$path_lower))
+  # Now test that the file is there.
+  # do a search for the path/file
+  # the make sure it exists
+
+  # cleanup
+  drop_delete(mtest)
+  unlink(file_name)
+})
+
+# --------------------------
+# Drop Create
+# --------------------------
+
+test_that("Drop create works correctly", {
+  folder_1 <- traceless("folder_1")
+  drop_create(folder_1)
+  expect_true(drop_is_folder(folder_1))
+  expect_error(drop_create(folder_1))
+  drop_create(folder_1, autorename = TRUE)
+  folder_duplicate <- paste0(folder_1, " (1)")
+  drop_delete(folder_1)
+  drop_delete(folder_duplicate)
+})
+
+# --------------------------
+# Drop Delete
+# --------------------------
+
+test_that("Drop delete works correctly", {
+  file_name <- traceless("delete.csv")
+  write.csv(iris, file = file_name)
+  drop_upload(file_name)
+  expect_equal(nrow(drop_dir()), 1)
+  drop_delete(file_name)
+  expect_equal(nrow(drop_dir()), 0)
+  fake_file <- traceless("delete.csv")
+  # Fails
+  expect_error(drop_delete(fake_file))
+})
+
+# --------------------------
+# Drop Exists
+# --------------------------
+
+test_that("drop_exists works correctly", {
+  skip_on_cran()
+
+  folder_name <- traceless("drop_exists")
+  drop_create(folder_name)
+
+  expect_true(drop_exists(folder_name))
+  expect_false(drop_exists(traceless("stuffnthings")))
+
+  # Now test files inside subfolders
+  write.csv(iris, file = "iris.csv")
+  drop_upload("iris.csv", path = folder_name)
+  expect_true(drop_exists(paste0(folder_name, "/iris.csv")))
+
+  #cleanup
+  drop_delete(folder_name)
+  unlink("iris.csv")
+})
+
+# --------------------------
+# Drop Misc
+# --------------------------
+
+
+

--- a/tests/testthat/test-07-drop_ops.R
+++ b/tests/testthat/test-07-drop_ops.R
@@ -1,5 +1,6 @@
 # !diagnostics off
 
+library(dplyr)
 context("Testing drop copy")
 # For now I haven't used traceless to make these tests more readable
 # while we work through them
@@ -7,8 +8,7 @@ context("Testing drop copy")
 expect_that("drop_copy works correctly", {
 # Copying files to files only
 # ------------------------
-# We need to start with a clean slate
-expect_equal(nrow(drop_dir()), 0)
+
 # Copy a file to a new name
 write.csv(iris, "iris.csv")
 drop_upload("iris.csv")

--- a/tests/testthat/test-07-drop_ops.R
+++ b/tests/testthat/test-07-drop_ops.R
@@ -6,61 +6,55 @@ context("Testing drop copy")
 # while we work through them
 
 expect_that("drop_copy works correctly", {
-
-# Copying files to files only
-# ------------------------
+# # Copying files to files only
+# # ------------------------
 # We need to start with a clean slate
-cfile_name <- traceless("iris-copy.csv")
+cfile_name <- traceless("iris-test-copy.csv")
 # Copy a file to a new name
 write.csv(iris, cfile_name)
 drop_upload(cfile_name)
-num_copy_files <- drop_dir()  %>% select(name, contains("iris-copy")) %>% nrow
+num_copy_files <- drop_file_count(cfile_name)
 expect_equal(num_copy_files, 1)
 # Copy to a new name, same folder
-cfile_name2 <- traceless("iris-copy.csv")
+cfile_name2 <- traceless("iris-test-copy.csv")
 drop_copy(cfile_name, cfile_name2)
-num_copy_files2 <- drop_dir()  %>% select(name, contains("iris-copy")) %>% nrow
+num_copy_files2 <- drop_file_count("iris-test-copy")
 expect_equal(num_copy_files2, 2)
 exp_2 <- sort(c(cfile_name, cfile_name2))
-server_exp_2 <- drop_dir() %>% dplyr::select(name) %>% pull %>% sort
+server_exp_2 <- sort(drop_dir()$name)
 expect_identical(exp_2, server_exp_2)
 # Copy to same name, but autorename is TRUE
 file_3 <- drop_copy(cfile_name, cfile_name, autorename = TRUE)
-num_copy_files3 <- drop_dir()  %>% select(name, contains("iris-copy")) %>% nrow
+num_copy_files3 <- drop_file_count("iris-test-copy")
 expect_equal(num_copy_files3 , 3)
-
-# Copying files to folders
-# ------------------------
+drop_delete(cfile_name2)
+#
+# # Copying files to folders
+# # ------------------------
 drop_create("copy_folder")
 drop_copy(cfile_name, "copy_folder")
-dc_dir <-  drop_dir("copy_folder") %>% dplyr::select(name, contains(cfile_name)) %>% pull
-expect_equal(dc_dir, cfile_name)
-
-# Copying folders to existing folders
-# ------------------------
+dc_dir <- drop_dir("copy_folder") %>% dplyr::select(name) %>% dplyr::pull()
+expect_identical(dc_dir, cfile_name)
+drop_delete(cfile_name)
+drop_delete(file_3$metadata$path_lower)
+#
+# # Copying folders to existing folders
+# # ------------------------
 drop_create("copy_folder_2")
 drop_copy("copy_folder", "copy_folder_2")
-copy_folder_2_contents <- drop_dir("copy_folder_2/copy_folder") %>% dplyr::select(name) %>% pull
-expect_equal(copy_folder_2_contents, cfile_name)
-
-# Copying files to new folders
-# ------------------------
+copy_folder_2_contents <- drop_dir("copy_folder_2/copy_folder") %>% dplyr::select(name) %>% dplyr::pull()
+expect_identical(copy_folder_2_contents, cfile_name)
+drop_delete("copy_folder_2")
+#
+# # Copying files to new folders
+# # ------------------------
 drop_copy("copy_folder", "kerfuffle")
-d1 <- drop_dir("copy_folder")  %>% dplyr::select(name) %>% pull %>% sort
-d2 <- drop_dir("kerfuffle")  %>% dplyr::select(name) %>% pull %>% sort
+d1 <- drop_dir("copy_folder") %>% dplyr::select(name) %>% dplyr::pull() %>% sort
+d2 <- drop_dir("kerfuffle") %>% dplyr::select(name) %>% dplyr::pull() %>% sort
 expect_identical(d1, d2)
-
 drop_delete("kerfuffle")
 drop_delete("copy_folder")
-drop_delete("copy_folder_2")
-drop_delete(cfile_name)
-drop_delete(cfile_name2)
-drop_delete(file_3$metadata$path_lower)
 })
-
-# TODO
-# We need to traceless() these files and folders
-# For now, I just wanted to keep them readable
 
 # --------------------------
 # Drop Move

--- a/tests/testthat/test-99-rdrop2.R
+++ b/tests/testthat/test-99-rdrop2.R
@@ -4,53 +4,7 @@
 
 context("old tests")
 
-# drop_copy
-test_that("Copying files works correctly", {
-  skip_on_cran()
 
-  file_name <- traceless("copy.csv")
-  folder_name <- traceless("drop_copy")
-  write.csv(iris, file = file_name)
-  drop_upload(file_name)
-  drop_create(folder_name)
-
-  # Try a duplicate create. This should fail
-  expect_error(drop_create(folder_name))
-  drop_upload(file_name)
-  drop_copy(file_name, paste0("/",folder_name, "/", file_name))
-
-  res <- drop_dir(folder_name)
-  expect_identical(basename(file_name), basename(res$path_lower))
-
-  # cleanup
-  drop_delete(folder_name)
-  unlink(file_name)
-  drop_delete(file_name)
-})
-
-
-# drop_move
-test_that("Moving files works correctly", {
-  skip_on_cran()
-
-  file_name <- traceless("move.csv")
-  write.csv(iris, file = file_name)
-  drop_upload(file_name)
-
-  mtest <- traceless("move_test")
-  drop_create(mtest)
-  drop_move(file_name, paste0("/", mtest, "/", file_name))
-  res <- drop_dir(mtest)
-  # problem
-  expect_identical(basename(file_name), basename(res$path_lower))
-  # Now test that the file is there.
-  # do a search for the path/file
-  # the make sure it exists
-
-  # cleanup
-  drop_delete(mtest)
-  unlink(file_name)
-})
 
 
 # drop_shared
@@ -129,26 +83,6 @@ test_that("drop_history works correctly", {
   unlink(file_name)
 })
 
-
-# drop_exists
-test_that("drop_exists works correctly", {
-  skip_on_cran()
-
-  folder_name <- traceless("drop_exists")
-  drop_create(folder_name)
-
-  expect_true(drop_exists(folder_name))
-  expect_false(drop_exists(traceless("stuffnthings")))
-
-  # Now test files inside subfolders
-  write.csv(iris, file = "iris.csv")
-  drop_upload("iris.csv", path = folder_name)
-  expect_true(drop_exists(paste0(folder_name, "/iris.csv")))
-
-  #cleanup
-  drop_delete(folder_name)
-  unlink("iris.csv")
-})
 
 
 # drop_media


### PR DESCRIPTION
This PR updates drop_copy, drop_move, drop_delete, and drop_create.

It also adds two new functions to check if an object is a folder/file on Dropbox, with a third wrapper that returns file, folder, or FALSE (for non-existent folder; this is necessary when you are copying to a new folder name).

Still needs work:
- [x] update tests for drop_move
-  [x] update tests for drop_create
- [x] update tests for drop_delete

The last 3 might not even be necessary.