### PR TITLE
Fix drop_download content bug

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rdrop2
 Title: Programmatic Interface to the 'Dropbox' API
-Version: 0.8.101
+Version: 0.8.1
 Authors@R: person("Karthik", "Ram", , "karthik.ram@gmail.com", c("aut", "cre"),
            person("Clayton", "Yochum", role = "aut"))
 Description: Provides full programmatic access to the Dropbox file hosting platform (dropbox.com), including support for all standard file operations.
@@ -8,14 +8,4 @@ Depends: R (>= 3.1.1)
 License: MIT + file LICENSE
 BugReports: https://github.com/karthik/rdrop2/issues
 LazyData: true
-Imports: 
-         assertive,
-         digest,
-         dplyr,
-         httr,
-         jsonlite,
-         magrittr,
-         purrr
-Suggests: testthat,
-          uuid
 RoxygenNote: 6.0.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rdrop2
 Title: Programmatic Interface to the 'Dropbox' API
-Version: 0.8.10
+Version: 0.8.101
 Authors@R: person("Karthik", "Ram", , "karthik.ram@gmail.com", c("aut", "cre"),
            person("Clayton", "Yochum", role = "aut"))
 Description: Provides full programmatic access to the Dropbox file hosting platform (dropbox.com), including support for all standard file operations.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rdrop2
 Title: Programmatic Interface to the 'Dropbox' API
-Version: 0.8.9999
+Version: 0.8.10
 Authors@R: person("Karthik", "Ram", , "karthik.ram@gmail.com", c("aut", "cre"),
            person("Clayton", "Yochum", role = "aut"))
 Description: Provides full programmatic access to the Dropbox file hosting platform (dropbox.com), including support for all standard file operations.

--- a/R/drop_download.R
+++ b/R/drop_download.R
@@ -78,7 +78,7 @@ drop_download <- function(
   }
 
   # return full path to file, invisibly
-  invisible(as.character(httr::content(req)))
+  invisible(TRUE)
 }
 
 

--- a/R/drop_download.R
+++ b/R/drop_download.R
@@ -77,8 +77,8 @@ drop_download <- function(
     ))
   }
 
-  # return full path to file, invisibly
-  invisible(TRUE)
+  # it should work
+  TRUE
 }
 
 

--- a/R/drop_download.R
+++ b/R/drop_download.R
@@ -78,7 +78,7 @@ drop_download <- function(
   }
 
   # return full path to file, invisibly
-  invisible(as.character(req$content))
+  invisible(as.character(httr::content(req)))
 }
 
 


### PR DESCRIPTION
`drop_download` function was returning the error: ` Error: $ operator is invalid for atomic vectors`, so despite downloading the file the application would crash after run it.