### PR TITLE
Fixes 0.8.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rdrop2
 Title: Programmatic Interface to the 'Dropbox' API
-Version: 0.8.9999
+Version: 0.8.1
 Authors@R: person("Karthik", "Ram", , "karthik.ram@gmail.com", c("aut", "cre"),
            person("Clayton", "Yochum", role = "aut"))
 Description: Provides full programmatic access to the Dropbox file hosting platform (dropbox.com), including support for all standard file operations.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# rdrop2 0.8.1
+* `drop_dir` now flattens nested responses so return can be coerced to `tbl_df`, e.g. if returned files/folders are shared with other (#135)
+* `drop_download` now returns `TRUE` when download was successful; should mitigate errors noted by multiple users (#132)
+
 # rdrop2 0.8 
 * This version is a major update from V1 of the Dropbox API (being deprecated on September 28, 2017) to V2. 🎉
 * `drop_acc` -  no longer returns quota information but still returns all other account related details. Quota retrieval will become available again on `0.9`

--- a/R/drop_dir.R
+++ b/R/drop_dir.R
@@ -107,7 +107,7 @@ drop_dir <- function(
   }
 
   # coerce to tibble, one row per item found
-  dplyr::bind_rows(results)
+  dplyr::bind_rows(purrr::map(results, LinearizeNestedList))
 }
 
 

--- a/R/drop_download.R
+++ b/R/drop_download.R
@@ -7,7 +7,7 @@
 #' @param verbose if TRUE, emit message giving location and size of the newly downloaded file. Defaults to TRUE in interactive sessions, otherwise FALSE.
 #' @template token
 #'
-#' @return path to location file downloaded to, invisibly
+#' @return TRUE if successful; error thrown otherwise.
 #'
 #' @examples \dontrun{
 #'
@@ -77,8 +77,8 @@ drop_download <- function(
     ))
   }
 
-  # return full path to file, invisibly
-  invisible(as.character(req$content))
+  # must have been successful
+  TRUE
 }
 
 
@@ -113,7 +113,8 @@ drop_get <- function(
 
   if (drop_exists(path, dtoken = dtoken)) {
     filename <- ifelse(is.null(local_file), basename(path), local_file)
-    filename <- drop_download(path, filename, overwrite, progress, verbose, dtoken)
+
+    drop_download(path, filename, overwrite, progress, verbose, dtoken)
 
     if (!verbose) {
       # prints file sizes in kb but this could also be pretty printed

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -2,4 +2,6 @@ Comments to CRAN maintainers:
 
 The package has no live examples or tests that run on CRAN because the package is a live interface to the Dropbox data storage platform. No API calls can be made to the API without authenticating into a live account. 
 
-On Travis CI, an encrypted token allows the maintainers to decrypt and run extensive tests on each commit/pull request. 
+On Travis CI, an encrypted token allows the maintainers to decrypt and run extensive tests on each commit/pull request.
+
+Several issues were caught by users shortly after 0.8 was released; 0.8.1 addresses these issues.

--- a/man/drop_download.Rd
+++ b/man/drop_download.Rd
@@ -26,7 +26,7 @@ authentication request. You can override this in \code{\link{drop_auth}} by
 pointing to a different location where your credentials are stored.}
 }
 \value{
-path to location file downloaded to, invisibly
+TRUE if successful; error thrown otherwise.
 }
 \description{
 Download a file from Dropbox to disk.

--- a/tests/testthat/helper-01.R
+++ b/tests/testthat/helper-01.R
@@ -22,15 +22,18 @@ traceless <- function(file) {
 
 
 # This should clean out any remaining/old test files and folders
-clean_test_data <- function(pattern = "rdrop_package_test", dtoken = get_dropbox_token()) {
-  x <- drop_dir() 
-  if(nrow(x) > 0) {
-  x1 <- x %>% dplyr::select(name) %>% pull
-  matching_files <- x1[grepl(pattern, x1)]
-  if(length(matching_files)) {
-  suppressWarnings(sapply(matching_files, drop_delete))
-}
-}
+clean_test_data <- function(pattern = "rdrop2_package_test", dtoken = get_dropbox_token()) {
+  files <- drop_dir()
+
+  if (nrow(files) > 0) {
+    filenames <- files[["name"]]
+
+    matching_files <- grep(pattern, filenames, value = TRUE)
+
+    if (length(matching_files)) {
+      suppressWarnings(purrr::walk(matching_files, drop_delete))
+    }
+  }
 }
 
 # Counts files matching a pattern

--- a/tests/testthat/test-06-rdrop2-download.R
+++ b/tests/testthat/test-06-rdrop2-download.R
@@ -10,26 +10,20 @@ test_that("drop_download works as expected", {
 
   # download to same path
   unlink(file_name)
-  expect_identical(
-    drop_download(file_name),
-    file_name
-  )
+  expect_true(drop_download(file_name))
+  expect_true(file.exists(file_name))
 
   # download to a new path
   new_path <- traceless("test-drop_download_newpath.csv")
-  expect_identical(
-    drop_download(file_name, new_path),
-    new_path
-  )
+  expect_true(drop_download(file_name, new_path))
+  expect_true(file.exists(new_path))
 
   # dowload to an implied path
   new_dir <- traceless("test-drop_download_newdir")
   dir.create(new_dir)
   implied_path <- file.path(new_dir, file_name)
-  expect_identical(
-    drop_download(file_name, new_dir),
-    implied_path
-  )
+  expect_true(drop_download(file_name, new_dir))
+  expect_true(file.exists(implied_path))
 
   # cleanup
   unlink(file_name)

--- a/tests/testthat/test-06-rdrop2-download.R
+++ b/tests/testthat/test-06-rdrop2-download.R
@@ -36,7 +36,7 @@ test_that("drop_get works, but is deprecated", {
   skip_on_cran()
 
   # create and upload a file for testing, then delete locally
-  file_name <- paste0("test-drop_download-", uuid::UUIDgenerate(), ".csv")
+  file_name <- traceless("test-drop_download.csv")
   write.csv(mtcars, file_name)
   drop_upload(file_name)
   unlink(file_name)


### PR DESCRIPTION
- Fixes #132 by returning TRUE when the download works
- Fixes #135 by flattening the nested listed before binding rows

Also improves tests by simplifying `clean_test_files` and converting another test to use `traceless`.