### PR TITLE
Change the argument 'dest' to 'path' in drop_upload() example in READ…

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ __csv files__
 write.csv(mtcars, 'mtcars.csv')
 drop_upload('mtcars.csv')
 # or upload to a specific folder
-drop_upload('mtcars.csv', dest = "drop_test")
+drop_upload('mtcars.csv', path = "drop_test")
 ```
 
 You can also do this for any other file type and large files are supported regardless of your memory.


### PR DESCRIPTION
…ME.md

According to the man page of drop_upload the name of the argument that specifies destination path of uploaded file is "path" and not "dest" - perhaps a vestige from the previous version of rdrop?

The only change made is to change 'dest' to 'path' in the example in README.md
