### PR TITLE
Use `add_slashes` in `drop_search

### DIFF
--- a/R/drop_search.R
+++ b/R/drop_search.R
@@ -34,7 +34,7 @@ drop_search <- function(query,
   args <- drop_compact(
     list(
       query = query,
-      path = path,
+      path = add_slashes(path),
       start = as.integer(start),
       max_results = as.integer(max_results),
       mode = mode


### PR DESCRIPTION
With `drop_search` the path needs a leading slash otherwise the API returns an error. `drop_search` now uses the `add_slashes` utility function. 