### PR TITLE
add query_authorize_extra optional parameter to drop_auth in order to…

### DIFF
--- a/R/drop_auth.R
+++ b/R/drop_auth.R
@@ -55,7 +55,8 @@ drop_auth <- function(new_user = FALSE,
                       key = "mmhfsybffdom42w",
                       secret = "l8zeqqqgm1ne5z0",
                       cache = TRUE,
-                      rdstoken = NA) {
+                      rdstoken = NA,
+                      query_authorize_extra = list()) {
 
   # check if token file exists & use it
   if (new_user == FALSE &  !is.na(rdstoken)) {
@@ -86,7 +87,8 @@ drop_auth <- function(new_user = FALSE,
     dropbox_app <- httr::oauth_app("dropbox", key, secret)
 
     # get the token
-    dropbox_token <- httr::oauth2.0_token(dropbox, dropbox_app, cache = cache)
+    dropbox_token <- httr::oauth2.0_token(dropbox, dropbox_app, cache = cache,
+                                          query_authorize_extra = query_authorize_extra)
 
     # make sure we got a token
     if (!inherits(dropbox_token, "Token2.0")) {


### PR DESCRIPTION
Add query_authorize_extra optional parameter to drop_auth in order to allow passing token_access_type = 'offline') to httr::oauth2.0_token

Fixes #201 

Dropbox changed their API to only allow short lived tokens by default, which is not usable from a server app (shiny for instance).
Instead, one must generate a refresh_token, and httr already has everything to work with a token generated this way. For the Dropbox API, this means passing an extra argument in the URL: token_access_type = "offline".

This can be done with the query_authorize_extra argument of httr::oauth2.0_token, as explained [here](https://www.tidyverse.org/blog/2018/12/httr-1-4-0/). This requires httr 1.4.0.

Then, to generate a token: `token <- drop_auth(query_authorize_extra = list(token_access_type = "offline")`
And to refresh: token$refresh().

An interesting addition would be to have rdrop2 manage the token refreshing when needed. It might already be done in httr2, but this would probably require further developments. This commit only addresses the creation of a token that includes both an access token (short lived) and a refresh token (long lived).