### PR TITLE
Replaced 'assertive' by 'assert_that'

### DIFF
--- a/.Rhistory
+++ b/.Rhistory
@@ -1,0 +1,2 @@
+library(devtools)
+load_all()

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rdrop2
 Title: Programmatic Interface to the 'Dropbox' API
-Version: 0.8.2.1
+Version: 0.8.2.2
 Authors@R: c(person("Karthik", "Ram", email = "karthik.ram@gmail.com", role = c("aut", "cre")),
            person("Clayton", "Yochum", role = "aut"),
            person("Caleb", "Scheidel", role = "ctb"),
@@ -11,14 +11,14 @@ Depends: R (>= 3.1.1)
 License: MIT + file LICENSE
 BugReports: https://github.com/karthik/rdrop2/issues
 LazyData: true
-Imports: 
-         assertive,
-         digest,
+Imports: digest,
          dplyr,
          httr,
          jsonlite,
          magrittr,
-         purrr
+         purrr,
+         assertthat
 Suggests: testthat,
           uuid
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.3
+Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# rdrop2 0.8.2.2
+* replaced dependency package `assertive` by `assertthat`.
+
 # rdrop2 0.8.2
 * Minor update to unarchive on CRAN (archived because assertive was archived)
 

--- a/R/drop_dir.R
+++ b/R/drop_dir.R
@@ -45,9 +45,12 @@ drop_dir <- function(
 ) {
 
   # check args
-  assertive::assert_is_a_string(path)
-  if (!is.null(limit)) assertive::assert_is_numeric(limit)
-  assertive::assert_is_any_of(cursor, c("logical", "character"))
+  #assertive::assert_is_a_string(path)
+  #if (!is.null(limit)) assertive::assert_is_numeric(limit)
+  #assertive::assert_is_any_of(cursor, c("logical", "character"))
+  assertthat::assert_that(is.character(path),
+                          is.null(limit) || is.numeric(limit),
+                          class(cursor) %in% c("logical", "character"))
 
   # this API doesn't accept "/", so don't add slashes to empty path, remove if given
   if (path != "") path <- add_slashes(path)

--- a/R/drop_download.R
+++ b/R/drop_download.R
@@ -110,7 +110,8 @@ drop_get <- function(
 
   .Deprecated("drop_download")
 
-  assertive::assert_is_not_null(path)
+  #assertive::assert_is_not_null(path)
+  assertthat::assert_that(!is.null(path))
 
   if (drop_exists(path, dtoken = dtoken)) {
     filename <- ifelse(is.null(local_file), basename(path), local_file)

--- a/R/drop_file_ops.R
+++ b/R/drop_file_ops.R
@@ -276,7 +276,9 @@ drop_create <-
 #'
 #' @export
 drop_exists <- function(path = NULL, dtoken = get_dropbox_token()) {
-  assertive::assert_is_not_null(path)
+  #assertive::assert_is_not_null(path)
+  assertthat::assert_that(!is.null(path))
+
   if (!grepl('^/', path))
     path <- paste0("/", path)
   dir_name <- suppressMessages(dirname(path))

--- a/R/drop_media.R
+++ b/R/drop_media.R
@@ -16,7 +16,9 @@
 #' drop_media('Public/gifs/duck_rabbit.gif')
 #'}
 drop_media <- function(path = NULL, dtoken = get_dropbox_token()) {
-  assertive::assert_is_not_null(path)
+  # assertive::assert_is_not_null(path)
+  assertthat::assert_that(!is.null(path))
+
   if(drop_exists(path)) {
     media_url <- "https://api.dropbox.com/2/files/get_temporary_link"
     path <- add_slashes(path)

--- a/R/drop_search.R
+++ b/R/drop_search.R
@@ -28,9 +28,14 @@ drop_search <- function(query,
                         dtoken = get_dropbox_token()) {
   available_modes <-
     c("filename", "filename_and_content", "deleted_filename")
-  assertive::assert_any_are_matching_fixed(available_modes, mode)
+  # assertive::assert_any_are_matching_fixed(available_modes, mode)
+  assertthat::assert_that(mode %in% available_modes)
+
   # A search cannot have a negative start index and a negative max_results
-  assertive::assert_all_are_non_negative(start, max_results)
+  #assertive::assert_all_are_non_negative(start, max_results)
+  assertthat::assert_that(start >= 0,
+                          max_results >= 0)
+
   args <- drop_compact(
     list(
       query = query,

--- a/R/drop_shared.R
+++ b/R/drop_shared.R
@@ -34,7 +34,8 @@ drop_share <- function(path = NULL,
 
   # Check to see if only supported modes are specified
   visibilities <- c("public", "team_only", "password")
-  assertive::assert_any_are_matching_fixed(visibilities, requested_visibility)
+  # assertive::assert_any_are_matching_fixed(visibilities, requested_visibility)
+  assertthat::assert_that(requested_visibility %in% visibilities)
 
   # TODO
   # Once the new drop_exists is done, one must check to see if a file/folder
@@ -57,7 +58,7 @@ drop_share <- function(path = NULL,
     url = share_url,
     httr::config(token = dtoken),
     body = list(path = path, settings = settings),
-    encode = "json" 
+    encode = "json"
   )
   # stopping for status otherwise content fails
   httr::stop_for_status(req)

--- a/R/drop_upload.R
+++ b/R/drop_upload.R
@@ -38,11 +38,13 @@ drop_upload <- function(file,
   put_url <- "https://content.dropboxapi.com/2/files/upload"
 
   # Check that object exists locally before adding slashes
-  assertive::assert_all_are_existing_files(file, severity = ("stop"))
+  # assertive::assert_all_are_existing_files(file, severity = ("stop"))
+  assertthat::assert_that(file.exists(file))
 
   # Check to see if only supported modes are specified
   standard_modes <- c("overwrite", "add", "update")
-  assertive::assert_any_are_matching_fixed(standard_modes, mode)
+  # assertive::assert_any_are_matching_fixed(standard_modes, mode)
+  assertthat::assert_that(mode %in% standard_modes)
 
   # Dropbox API requires a / before an object name.
   if (is.null(path)) {

--- a/R/drop_utils.R
+++ b/R/drop_utils.R
@@ -193,7 +193,8 @@ LinearizeNestedList <- function(NList, LinearizeDataFrames=FALSE,
 #' @noRd
 pretty_lists <- function(x)
 {
-  assertive::assert_is_list(x)
+  # assertive::assert_is_list(x)
+  assertthat::assert_that(is.list(x))
 
    for(key in names(x)){
       value <- format(x[[key]])


### PR DESCRIPTION
Replaced all assertive functions by their assert_that counterparts and updated DESCRIPTION to reflect change in dependencies.

Fixes #207 

Cheers,
Felipe 